### PR TITLE
Fix NullPointerException when host leaves duel

### DIFF
--- a/src/main/java/dev/efnilite/ip/world/Divider.java
+++ b/src/main/java/dev/efnilite/ip/world/Divider.java
@@ -51,6 +51,9 @@ public class Divider {
      * @param session The session.
      */
     public static void remove(Session session) {
+	if (!sections.containsKey(session)) {
+    		return;
+	}
         IP.log("Removed session at %s".formatted(Locations.toString(toLocation(session), true)));
 
         sections.remove(session);
@@ -61,6 +64,9 @@ public class Divider {
      * @return The location at the center of section n.
      */
     private static Location toLocation(Session session) {
+	if (!sections.containsKey(session)) {
+    		return null;
+	}
         int[] xz = spiralAt(sections.get(session));
 
         return new Location(World.getWorld(),


### PR DESCRIPTION
### Bug Fix: Host Player Disconnect

#### Issue:
The game crashes with a `NullPointerException` when the host player leaves the duel, as the code doesn't properly handle the case when the host disconnects.

#### Fix:
- Added null checks in the relevant parts of the code to ensure that a `NullPointerException` is not thrown when trying to access null values.
- Specifically updated the `Divider.remove()` method and added checks to the `toLocation()` method to prevent errors when the session is null.

#### Why this is important:
This fix prevents crashes when the host leaves the duel, improving the overall stability of the game and ensuring a smoother experience for players.